### PR TITLE
fix(head): allow script to be used from h2 push

### DIFF
--- a/head.html
+++ b/head.html
@@ -1,4 +1,4 @@
 <link id="favicon" rel="icon" type="image/svg+xml" href="/express/icons/spark.svg">
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
-<script src="/express/scripts/scripts.js" type="module" crossorigin="anonymous"></script>
+<script src="/express/scripts/scripts.js" type="module"></script>
 <link rel="stylesheet" href="/express/styles/styles.css"/>


### PR DESCRIPTION
fixes #43

The corresponding change on the Fastly side has already been activated in the outer CDN (version 35)
