### PR TITLE
fix(a11y): use A for cards

### DIFF
--- a/express/blocks/blog-posts/blog-posts.css
+++ b/express/blocks/blog-posts/blog-posts.css
@@ -19,6 +19,8 @@ main .blog-posts .hero-card {
   box-sizing: border-box;
   margin: 0;
   border: 0;
+  text-decoration: unset;
+  color: unset;
 }
 
 main .blog-posts .hero-card .card-image {
@@ -52,6 +54,8 @@ main .blog-posts .card {
     width: 350px;
     margin: 10px;
     text-align: left;
+    text-decoration: unset;
+    color: unset;
   }
 
   main .blog-posts .card .card-image {

--- a/express/blocks/blog-posts/blog-posts.js
+++ b/express/blocks/blog-posts/blog-posts.js
@@ -125,7 +125,10 @@ async function decorateBlogPosts($blogPosts, config, offset = 0) {
         <img src="./media_${imagePath}?width=2000&format=webply&optimize=medium">
       </picture>`;
     }
-    const $card = createTag('div', { class: `${isHero ? 'hero-card' : 'card'}` });
+    const $card = createTag('a', {
+      class: `${isHero ? 'hero-card' : 'card'}`,
+      href: path,
+    });
     $card.innerHTML = `<div class="card-image">
           ${pictureTag}
         </div>
@@ -134,9 +137,6 @@ async function decorateBlogPosts($blogPosts, config, offset = 0) {
         <h3>${title}</h3>
           <p>${teaser}</p>
         </div>`;
-    $card.addEventListener('click', () => {
-      window.location.href = `${path}`;
-    });
     if (isHero) $blogPosts.prepend($card);
     else $cards.append($card);
   }


### PR DESCRIPTION
fixes #35 

using an `<A>` for cards solves a lot of a11y problems:

- tabindex works
- focus indicator works
- link can be _"clicked"_ with keyboard (enter)
- screen reader can read contents of link