### PR TITLE
fix(a11y): ensure that templates are keyboard selectable

### DIFF
--- a/express/blocks/template-list/template-list.css
+++ b/express/blocks/template-list/template-list.css
@@ -8,7 +8,7 @@ main .template-list {
     text-align: left;
 }
 
-main .template-list a:any-link {
+main .template-list .template-link {
     text-decoration: none;
     color: #1473E6;
     padding-left: 16px;
@@ -16,11 +16,7 @@ main .template-list a:any-link {
     display: flex;
 }
 
-main .template-list > div > div:first-child > a:any-link {
-  padding-left: 0;
-}
-
-main .template-list div > div:nth-child(2) a:any-link::after {
+main .template-list .template-link::after {
     display: flex;
     width: 6px;
     height: 6px;
@@ -38,11 +34,11 @@ main .template-list div > div:nth-child(2) a:any-link::after {
     margin-right: 2.25px;
 }
 
-main .template-list > div p {
+main .template-list .template p {
     margin: 0;
 }
 
-main .template-list > div {
+main .template-list .template {
     display: flex;
     flex-direction: column;
     width: 300px;
@@ -51,25 +47,29 @@ main .template-list > div {
     -webkit-column-break-inside: avoid;
     page-break-inside: avoid;
     break-inside: avoid;
+    text-decoration: unset;
 }
 
+main .template-list .template > div:first-child > a:any-link {
+    padding-left: 0;
+}
 
-main .template-list > div img, main .template-list > div video {
+main .template-list .template img, main .template-list .template video {
     border-radius: 10px;
     width: 300px;
 }
 
-main .template-list.large > div {
+main .template-list.large .template {
     width: 100%;
     margin: 0;
     border: 0;
 }
 
-main .template-list.large > div > div {
+main .template-list.large .template > div {
     margin: auto;
 }
 
-main .template-list.large > div img {
+main .template-list.large .template img {
     width: 100%;
 }
 
@@ -78,23 +78,22 @@ main .template-list + .button-container > a {
 }
 
 
-main .template-list.masonry > div {
-    margin-top: 0px;
+main .template-list.masonry .template {
+    margin-top: 0;
+    margin-bottom: 32px;
     padding: 0;
-    margin-bottom: 0;
-    padding-bottom: 32px;
 }
 
 @media (min-width: 600px) {
-    main .template-list > div {
+    main .template-list .template {
         width: 240px;
         margin: 12px;
     }
-    
-    main .template-list > div img {
+
+    main .template-list .template img {
         width: 240px;
     }
-    
+
     main .template-list.masonry {
         display: block;
         columns: 240px 2;
@@ -148,12 +147,12 @@ main .template-list.masonry > div {
     flex-wrap: nowrap;
   }
 
-  main .columns .template-list > div {
+  main .columns .template-list .template {
     justify-content: flex-start;
     min-width: 132px;
   }
 
-  main .columns .template-list a:any-link {
+  main .columns .template-list .template-link {
     font-size: 0.875rem;
     font-weight: 500;;
   }

--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -51,8 +51,8 @@ async function decorateTemplateList($block) {
     }
     const $heroPicture = document.querySelector('.hero-bg');
 
-    if (!$heroPicture && window.spark.$blueprint) {
-      const $bpHeroImage = window.spark.$blueprint.querySelector('div:first-of-type img');
+    if (!$heroPicture && $blueprint) {
+      const $bpHeroImage = $blueprint.querySelector('div:first-of-type img');
       if ($bpHeroImage) {
         const $heroSection = document.querySelector('main .hero');
         const $heroDiv = document.querySelector('main .hero > div');
@@ -77,6 +77,34 @@ async function decorateTemplateList($block) {
     $block.classList.add('large');
   }
 
+  // find the edit link and turn the template DIV into the A
+  // A
+  // +- DIV
+  //    +- PICTURE
+  // +- DIV
+  //    +- SPAN
+  //       +- "Edit this template"
+  //
+  // make copy of children to avoid modifying list while looping
+  for (const $tmplt of Array.from($block.children)) {
+    const $link = $tmplt.querySelector(':scope > div:last-of-type > a');
+    if ($link) {
+      const $a = createTag('a', {
+        href: $link.href || '#',
+        class: 'template',
+      });
+      $a.append(...$tmplt.childNodes);
+      $block.append($a);
+
+      // convert A to SPAN
+      const $newLink = createTag('span', { class: 'template-link' });
+      $newLink.append(...$link.childNodes);
+      $link.parentNode.append($newLink);
+      $link.remove();
+    }
+  }
+
+  // wrap "linked images" with link
   $block.querySelectorAll(':scope > div > div:first-of-type a').forEach(($a) => {
     const $parent = $a.closest('div');
     if (!$a.href.includes('.mp4')) {

--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -86,7 +86,7 @@ async function decorateTemplateList($block) {
   //       +- "Edit this template"
   //
   // make copy of children to avoid modifying list while looping
-  for (const $tmplt of Array.from($block.children)) {
+  for (let $tmplt of Array.from($block.children)) {
     const $link = $tmplt.querySelector(':scope > div:last-of-type > a');
     if ($link) {
       const $a = createTag('a', {
@@ -94,6 +94,8 @@ async function decorateTemplateList($block) {
         class: 'template',
       });
       $a.append(...$tmplt.childNodes);
+      $tmplt.remove();
+      $tmplt = $a;
       $block.append($a);
 
       // convert A to SPAN
@@ -102,30 +104,36 @@ async function decorateTemplateList($block) {
       $link.parentNode.append($newLink);
       $link.remove();
     }
-  }
 
-  // wrap "linked images" with link
-  $block.querySelectorAll(':scope > div > div:first-of-type a').forEach(($a) => {
-    const $parent = $a.closest('div');
-    if (!$a.href.includes('.mp4')) {
-      linkImage($parent);
-    } else {
-      const $picture = $parent.querySelector('picture');
-      const $video = createTag('video', {
-        playsinline: '',
-        autoplay: '',
-        loop: '',
-        muted: '',
-      });
-      $video.innerHTML = `<source src="${$a.href}" type="video/mp4">`;
-      $parent.replaceChild($video, $picture);
-      $a.remove();
-      $video.addEventListener('canplay', () => {
-        $video.muted = true;
-        $video.play();
-      });
+    // wrap "linked images" with link
+    const $imgLink = $tmplt.querySelector(':scope > div:first-of-type a');
+    if ($imgLink) {
+      const $parent = $imgLink.closest('div');
+      if (!$imgLink.href.includes('.mp4')) {
+        linkImage($parent);
+      } else {
+        const $picture = $tmplt.querySelector('picture');
+        if ($picture) {
+          const $video = createTag('video', {
+            playsinline: '',
+            autoplay: '',
+            loop: '',
+            muted: '',
+          });
+          $video.append(createTag('source', {
+            src: $imgLink.href,
+            type: 'video/mp4',
+          }));
+          $parent.replaceChild($video, $picture);
+          $imgLink.remove();
+          $video.addEventListener('canplay', () => {
+            $video.muted = true;
+            $video.play();
+          });
+        }
+      }
     }
-  });
+  }
 }
 
 export default function decorate($block) {

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -63,13 +63,14 @@ export function getIconElement(icon) {
 
 export function linkImage($elem) {
   const $a = $elem.querySelector('a');
-  const $parent = $a.closest('div');
-  $a.remove();
-  const picture = $parent.innerHTML;
-  $parent.innerHTML = '';
-  $parent.appendChild($a);
-  $a.innerHTML = picture;
-  $a.className = '';
+  if ($a) {
+    const $parent = $a.closest('div');
+    $a.remove();
+    $a.className = '';
+    $a.innerHTML = '';
+    $a.append(...$parent.childNodes);
+    $parent.append($a);
+  }
 }
 
 function wrapSections(element) {

--- a/test/unit/blocks/blocks.test.js
+++ b/test/unit/blocks/blocks.test.js
@@ -67,7 +67,7 @@ describe('Block tests', () => {
       const mod = await import(`/express/blocks/${blockName}/${blockName}.js`);
       mod.default(block, blockName, doc);
 
-      expect(fragmentToString(expected)).to.be.equal(fragmentToString(block));
+      expect(fragmentToString(block)).to.be.equal(fragmentToString(expected));
     });
   });
 });

--- a/test/unit/blocks/expected/template-list.linkwithtext.block.html
+++ b/test/unit/blocks/expected/template-list.linkwithtext.block.html
@@ -1,5 +1,5 @@
 <div class="template-list large">
-  <div>
+  <a href="https://spark.adobe.com/post/BshlLeOZHhNAy" class="template">
     <div>
       <picture>
         <source media="(max-width: 400px)"
@@ -8,6 +8,6 @@
           alt="" loading="lazy">
       </picture>
     </div>
-    <div><a href="https://spark.adobe.com/post/BshlLeOZHhNAy">Edit this template</a></div>
-  </div>
+    <div><span class="template-link">Edit this template</span></div>
+  </a>
 </div>

--- a/test/unit/blocks/expected/template-list.video.block.html
+++ b/test/unit/blocks/expected/template-list.video.block.html
@@ -1,10 +1,10 @@
 <div class="template-list large">
-  <div>
+  <a href="https://adobesparkpost.app.link/v4MgmgR443" class="template">
     <div><video playsinline="" autoplay="" loop="" muted="">
         <source
           src="https://cdn.cp.adobe.io/content/2/dcx/7f2115c0-50ab-4389-a32d-572ce1d82bf1/content/videoRendition.mp4/version/0"
           type="video/mp4">
       </video></div>
-    <div><a href="https://adobesparkpost.app.link/v4MgmgR443">Edit this template</a></div>
-  </div>
+    <div><span class="template-link">Edit this template</span></div>
+  </a>
 </div>


### PR DESCRIPTION
fixes #36
fixes #64

- replace template DIV with A to the `edit this template` link
- use span for `edit this template` link to avoid link in link
