### PR TITLE
fix(safari): fix webp dectection method

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 /* global window, navigator, document, fetch, performance, PerformanceObserver,
-   localStorage, FontFace, sessionStorage */
+   localStorage, FontFace, sessionStorage, Image */
 /* eslint-disable no-console */
 
 export function toClassName(name) {
@@ -916,19 +916,28 @@ function splitSections() {
 }
 
 function supportsWebp() {
-  if (window.name.includes('nowebp')) return false;
-  if (window.name.includes('webp')) return true;
+  return window.webpSupport;
+}
 
-  if (window.webpSupport === undefined) {
-    window.webpSupport = true;
-    const $canvas = document.createElement('canvas');
-    if ($canvas.getContext && $canvas.getContext('2d')) {
-      window.webpSupport = $canvas.toDataURL('image/webp').startsWith('data:image/webp');
-    } else {
-      window.webpSupport = false;
-    }
-  }
-  return (window.webpSupport);
+// Google official webp detection
+function checkWebpFeature(feature, callback) {
+  const kTestImages = {
+    lossy: 'UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoBAAEADsD+JaQAA3AAAAAA',
+    lossless: 'UklGRhoAAABXRUJQVlA4TA0AAAAvAAAAEAcQERGIiP4HAA==',
+    alpha: 'UklGRkoAAABXRUJQVlA4WAoAAAAQAAAAAAAAAAAAQUxQSAwAAAARBxAR/Q9ERP8DAABWUDggGAAAABQBAJ0BKgEAAQAAAP4AAA3AAP7mtQAAAA==',
+    animation: 'UklGRlIAAABXRUJQVlA4WAoAAAASAAAAAAAAAAAAQU5JTQYAAAD/////AABBTk1GJgAAAAAAAAAAAAAAAAAAAGQAAABWUDhMDQAAAC8AAAAQBxAREYiI/gcA',
+  };
+  const img = new Image();
+  img.onload = () => {
+    const result = (img.width > 0) && (img.height > 0);
+    window.webpSupport = result;
+    callback();
+  };
+  img.onerror = () => {
+    window.webpSupport = false;
+    callback();
+  };
+  img.src = `data:image/webp;base64,${kTestImages[feature]}`;
 }
 
 export function getOptimizedImageURL(src) {
@@ -965,12 +974,14 @@ function resetAttribute($elem, attrib) {
 }
 
 export function webpPolyfill(element) {
-  element.querySelectorAll('img').forEach(($img) => {
-    resetAttribute($img, 'src');
-  });
-  element.querySelectorAll('picture source').forEach(($source) => {
-    resetAttribute($source, 'srcset');
-  });
+  if (!supportsWebp()) {
+    element.querySelectorAll('img').forEach(($img) => {
+      resetAttribute($img, 'src');
+    });
+    element.querySelectorAll('picture source').forEach(($source) => {
+      resetAttribute($source, 'srcset');
+    });
+  }
 }
 
 function setTheme() {
@@ -1101,7 +1112,9 @@ async function decoratePage() {
   decorateHero();
   decorateButtons();
   fixIcons();
-  webpPolyfill(document);
+  checkWebpFeature('lossy', () => {
+    webpPolyfill(document);
+  });
   decorateBlocks();
   decorateDoMoreEmbed();
   decorateLinkedPictures();

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -920,13 +920,8 @@ function supportsWebp() {
 }
 
 // Google official webp detection
-function checkWebpFeature(feature, callback) {
-  const kTestImages = {
-    lossy: 'UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoBAAEADsD+JaQAA3AAAAAA',
-    lossless: 'UklGRhoAAABXRUJQVlA4TA0AAAAvAAAAEAcQERGIiP4HAA==',
-    alpha: 'UklGRkoAAABXRUJQVlA4WAoAAAAQAAAAAAAAAAAAQUxQSAwAAAARBxAR/Q9ERP8DAABWUDggGAAAABQBAJ0BKgEAAQAAAP4AAA3AAP7mtQAAAA==',
-    animation: 'UklGRlIAAABXRUJQVlA4WAoAAAASAAAAAAAAAAAAQU5JTQYAAAD/////AABBTk1GJgAAAAAAAAAAAAAAAAAAAGQAAABWUDhMDQAAAC8AAAAQBxAREYiI/gcA',
-  };
+function checkWebpFeature(callback) {
+  const kTestImages = 'UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoBAAEADsD+JaQAA3AAAAAA';
   const img = new Image();
   img.onload = () => {
     const result = (img.width > 0) && (img.height > 0);
@@ -937,7 +932,7 @@ function checkWebpFeature(feature, callback) {
     window.webpSupport = false;
     callback();
   };
-  img.src = `data:image/webp;base64,${kTestImages[feature]}`;
+  img.src = `data:image/webp;base64,${kTestImages}`;
 }
 
 export function getOptimizedImageURL(src) {
@@ -1150,7 +1145,7 @@ async function decoratePage() {
   decorateHero();
   decorateButtons();
   fixIcons();
-  checkWebpFeature('lossy', () => {
+  checkWebpFeature(() => {
     webpPolyfill(document);
   });
   decorateBlocks();

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 /* global window, navigator, document, fetch, performance, PerformanceObserver,
-   localStorage, FontFace, sessionStorage, Image */
+          FontFace, sessionStorage, Image */
 /* eslint-disable no-console */
 
 export function toClassName(name) {

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -921,18 +921,26 @@ function supportsWebp() {
 
 // Google official webp detection
 function checkWebpFeature(callback) {
-  const kTestImages = 'UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoBAAEADsD+JaQAA3AAAAAA';
-  const img = new Image();
-  img.onload = () => {
-    const result = (img.width > 0) && (img.height > 0);
-    window.webpSupport = result;
+  const webpSupport = sessionStorage.getItem('webpSupport');
+  if (!webpSupport) {
+    const kTestImages = 'UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoBAAEADsD+JaQAA3AAAAAA';
+    const img = new Image();
+    img.onload = () => {
+      const result = (img.width > 0) && (img.height > 0);
+      window.webpSupport = result;
+      sessionStorage.setItem('webpSupport', result);
+      callback();
+    };
+    img.onerror = () => {
+      sessionStorage.setItem('webpSupport', false);
+      window.webpSupport = false;
+      callback();
+    };
+    img.src = `data:image/webp;base64,${kTestImages}`;
+  } else {
+    window.webpSupport = (webpSupport === 'true');
     callback();
-  };
-  img.onerror = () => {
-    window.webpSupport = false;
-    callback();
-  };
-  img.src = `data:image/webp;base64,${kTestImages}`;
+  }
 }
 
 export function getOptimizedImageURL(src) {


### PR DESCRIPTION
Fix https://github.com/adobe/spark-website-issues/issues/30

This is what's needed to fix the webp detection properly (we could remove the various test mechanism we do not use). I do not think this break the perf (still want to test) but for sure loading a fake image on each page load just to test if webp is supported is not a brilliant idea.

I want to test something else: move the `webpPolyfill` call in the error handler of the hero image loading. The hero image loading would then serve as the check.