### PR TITLE
Decorate links for lower envs

### DIFF
--- a/express/scripts/martech.js
+++ b/express/scripts/martech.js
@@ -451,6 +451,18 @@ loadScript('https://www.adobe.com/etc.clientlibs/globalnav/clientlibs/base/feds.
     const placeholder = document.getElementById('header-placeholder');
     gnav.classList.add('appear');
     placeholder.classList.add('disappear');
+
+    /* switch all links if lower envs */
+    const env = getHelixEnv();
+    if (env && env.spark) {
+      // eslint-disable-next-line no-console
+      console.log('lower env detected');
+      document.querySelectorAll('a[href^="https://spark.adobe.com/"]').forEach(($a) => {
+        const hrefURL = new URL($a.href);
+        hrefURL.host = env.spark;
+        $a.setAttribute('href', hrefURL.toString());
+      });
+    }
   }, 500);
 }).id = 'feds-script';
 

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1108,7 +1108,7 @@ function displayEnv() {
     if (document.referrer) {
       const url = new URL(document.referrer);
       if (url.hostname.endsWith === '.adobeprojectm.com') {
-        setHelixEnv('stage', { spark: url.hostname });
+        setHelixEnv('stage', { spark: url.host });
       }
       if (window.location.hostname !== url.hostname) {
         console.log(`external referrer detected: ${document.referrer}`);

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1121,7 +1121,7 @@ function displayEnv() {
     /* setup based on referrer */
     if (document.referrer) {
       const url = new URL(document.referrer);
-      if (url.hostname.endsWith === '.adobeprojectm.com') {
+      if (url.hostname.endsWith('.adobeprojectm.com')) {
         setHelixEnv('stage', { spark: url.host });
       }
       if (window.location.hostname !== url.hostname) {


### PR DESCRIPTION
to add round tripping from test, dev envs we rewrite links to spark.adobe.com with their original destination

https://decorate-links-for-lower-envs--spark-website--adobe.hlx.page/express/?helix-env=stage