### PR TITLE
chore: quick workaround for main-- prefix

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1173,7 +1173,12 @@ async function decoratePage() {
   document.body.classList.add('appear');
 
   // this is a temporary fix for a preview URL mismatch
-  tempRedirect();
+  try {
+    tempRedirect();
+  } catch (e) {
+    // something went wrong
+    console.log(`temp redirect failed ${e.message}`);
+  }
 }
 
 window.spark = {};

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1080,6 +1080,13 @@ export function getHelixEnv() {
   return env;
 }
 
+/* this is a workaround for a preview URL sidekick mismatch */
+function tempRedirect() {
+  if (window.location && window.location.hostname && window.location.hostname.startsWith('main--')) {
+    window.location.href = window.location.href.replace('main--', '');
+  }
+}
+
 function displayOldLinkWarning() {
   if (window.location.hostname.includes('localhost') || window.location.hostname.includes('.hlx.page')) {
     document.querySelectorAll('main a[href^="https://spark.adobe.com/"]').forEach(($a) => {
@@ -1164,6 +1171,9 @@ async function decoratePage() {
   displayEnv();
   displayOldLinkWarning();
   document.body.classList.add('appear');
+
+  // this is a temporary fix for a preview URL mismatch
+  tempRedirect();
 }
 
 window.spark = {};


### PR DESCRIPTION
due to a mismatch of the preview URL generation and sidekick behavior we need a quick way to redirect from the `main--` urls to the URLs without.