### PR TITLE
fix(webp): catch image loading errors

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1187,7 +1187,7 @@ function setupImageErrorDetection() {
   document.querySelectorAll('img').forEach(($img) => {
     if (!$img.complete) {
       $img.addEventListener('error', () => {
-        console.warn(`detected potential broken image ${$img.src} - trying without webp`);
+        console.warn(`detected broken image ${$img.src} - trying without webp`);
         resetAttribute($img, 'src', true);
       });
     } else if ($img.width === 0 && $img.height === 0) {

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -943,14 +943,14 @@ function checkWebpFeature(callback) {
   }
 }
 
-export function getOptimizedImageURL(src) {
+export function getOptimizedImageURL(src, noWebp) {
   const url = new URL(src, window.location.href);
   let result = src;
   const { pathname, search } = url;
   if (pathname.includes('media_')) {
     const usp = new URLSearchParams(search);
     usp.delete('auto');
-    if (!supportsWebp()) {
+    if (noWebp || !supportsWebp()) {
       if (pathname.endsWith('.png')) {
         usp.set('format', 'png');
       } else if (pathname.endsWith('.gif')) {
@@ -966,10 +966,10 @@ export function getOptimizedImageURL(src) {
   return (result);
 }
 
-function resetAttribute($elem, attrib) {
+function resetAttribute($elem, attrib, force) {
   const src = $elem.getAttribute(attrib);
   if (src) {
-    const oSrc = getOptimizedImageURL(src);
+    const oSrc = getOptimizedImageURL(src, force);
     if (oSrc !== src) {
       $elem.setAttribute(attrib, oSrc);
     }
@@ -1182,6 +1182,16 @@ async function decoratePage() {
 }
 
 window.spark = {};
+
+function setupImageErrorDetection() {
+  document.querySelectorAll('img').forEach(($img) => {
+    $img.addEventListener('error', () => {
+      resetAttribute($img, 'src', true);
+    });
+  });
+}
+
+setupImageErrorDetection();
 decoratePage();
 
 /* performance instrumentation */

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1185,18 +1185,16 @@ window.spark = {};
 
 function setupImageErrorDetection() {
   document.querySelectorAll('img, picture source').forEach(($img) => {
-    $img.addEventListener('error', () => {
-      console.error('img on error');
+    if (!$img.complete) {
+      $img.addEventListener('error', () => {
+        console.error('img on error');
+        resetAttribute($img, 'src', true);
+      });
+    } else if ($img.width === 0 && $img.height === 0) {
+      // a loaded img with w=0 anh h-0 is potentially a broken image
+      console.log(`detected potential broken image ${$img.src}`);
       resetAttribute($img, 'src', true);
-    });
-    $img.addEventListener('abort', () => {
-      console.error('img on abort');
-      resetAttribute($img, 'src', true);
-    });
-    $img.addEventListener('stalled', () => {
-      console.error('img on stalled');
-      resetAttribute($img, 'src', true);
-    });
+    }
   });
 }
 

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -966,10 +966,10 @@ export function getOptimizedImageURL(src, noWebp) {
   return (result);
 }
 
-function resetAttribute($elem, attrib, force) {
+function resetAttribute($elem, attrib, noWebp) {
   const src = $elem.getAttribute(attrib);
   if (src) {
-    const oSrc = getOptimizedImageURL(src, force);
+    const oSrc = getOptimizedImageURL(src, noWebp);
     if (oSrc !== src) {
       $elem.setAttribute(attrib, oSrc);
     }
@@ -1186,6 +1186,15 @@ window.spark = {};
 function setupImageErrorDetection() {
   document.querySelectorAll('img').forEach(($img) => {
     $img.addEventListener('error', () => {
+      console.error('img on error');
+      resetAttribute($img, 'src', true);
+    });
+    $img.addEventListener('abort', () => {
+      console.error('img on abort');
+      resetAttribute($img, 'src', true);
+    });
+    $img.addEventListener('stalled', () => {
+      console.error('img on stalled');
       resetAttribute($img, 'src', true);
     });
   });

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1184,7 +1184,7 @@ async function decoratePage() {
 window.spark = {};
 
 function setupImageErrorDetection() {
-  document.querySelectorAll('img').forEach(($img) => {
+  document.querySelectorAll('img, picture source').forEach(($img) => {
     $img.addEventListener('error', () => {
       console.error('img on error');
       resetAttribute($img, 'src', true);

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1187,12 +1187,12 @@ function setupImageErrorDetection() {
   document.querySelectorAll('img').forEach(($img) => {
     if (!$img.complete) {
       $img.addEventListener('error', () => {
-        console.warning(`detected potential broken image ${$img.src} - trying without webp`);
+        console.warn(`detected potential broken image ${$img.src} - trying without webp`);
         resetAttribute($img, 'src', true);
       });
     } else if ($img.width === 0 && $img.height === 0) {
       // a loaded img with w=0 anh h-0 is potentially a broken image
-      console.warning(`detected potential broken image (0,0) ${$img.src} - trying without webp`);
+      console.warn(`detected potential broken image (0,0) ${$img.src} - trying without webp`);
       resetAttribute($img, 'src', true);
     }
   });

--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -1184,15 +1184,15 @@ async function decoratePage() {
 window.spark = {};
 
 function setupImageErrorDetection() {
-  document.querySelectorAll('img, picture source').forEach(($img) => {
+  document.querySelectorAll('img').forEach(($img) => {
     if (!$img.complete) {
       $img.addEventListener('error', () => {
-        console.error('img on error');
+        console.warning(`detected potential broken image ${$img.src} - trying without webp`);
         resetAttribute($img, 'src', true);
       });
     } else if ($img.width === 0 && $img.height === 0) {
       // a loaded img with w=0 anh h-0 is potentially a broken image
-      console.log(`detected potential broken image ${$img.src}`);
+      console.warning(`detected potential broken image (0,0) ${$img.src} - trying without webp`);
       resetAttribute($img, 'src', true);
     }
   });


### PR DESCRIPTION
Fix https://github.com/adobe/spark-website-issues/issues/42

We need to detect if image fails to load but if the image is already in the browser cache, we also need another trick. I used width=0 and height=0. This seems to work.

I tested https://catch-img-errors--spark-website--adobe.hlx.page/express/affiliate/special-20 on Safari 14.0.3 (fixes the issue), Safari 13 (webp detection still works) and on Chrome (code not called). But there are certainly some undetermined edge cases somewhere...