### PR TITLE
fix(webp): ensure correct url is used for browsers not supporting webp

### DIFF
--- a/express/scripts/scripts.js
+++ b/express/scripts/scripts.js
@@ -612,6 +612,78 @@ async function loadFonts() {
   document.body.classList.add('font-loaded');
 }
 
+function supportsWebp() {
+  return window.webpSupport;
+}
+
+// Google official webp detection
+function checkWebpFeature(callback) {
+  const webpSupport = sessionStorage.getItem('webpSupport');
+  if (!webpSupport) {
+    const kTestImages = 'UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoBAAEADsD+JaQAA3AAAAAA';
+    const img = new Image();
+    img.onload = () => {
+      const result = (img.width > 0) && (img.height > 0);
+      window.webpSupport = result;
+      sessionStorage.setItem('webpSupport', result);
+      callback();
+    };
+    img.onerror = () => {
+      sessionStorage.setItem('webpSupport', false);
+      window.webpSupport = false;
+      callback();
+    };
+    img.src = `data:image/webp;base64,${kTestImages}`;
+  } else {
+    window.webpSupport = (webpSupport === 'true');
+    callback();
+  }
+}
+
+export function getOptimizedImageURL(src) {
+  const url = new URL(src, window.location.href);
+  let result = src;
+  const { pathname, search } = url;
+  if (pathname.includes('media_')) {
+    const usp = new URLSearchParams(search);
+    usp.delete('auto');
+    if (!supportsWebp()) {
+      if (pathname.endsWith('.png')) {
+        usp.set('format', 'png');
+      } else if (pathname.endsWith('.gif')) {
+        usp.set('format', 'gif');
+      } else {
+        usp.set('format', 'pjpg');
+      }
+    } else {
+      usp.set('format', 'webply');
+    }
+    result = `${src.split('?')[0]}?${usp.toString()}`;
+  }
+  return (result);
+}
+
+function resetAttribute($elem, attrib) {
+  const src = $elem.getAttribute(attrib);
+  if (src) {
+    const oSrc = getOptimizedImageURL(src);
+    if (oSrc !== src) {
+      $elem.setAttribute(attrib, oSrc);
+    }
+  }
+}
+
+export function webpPolyfill(element) {
+  if (!supportsWebp()) {
+    element.querySelectorAll('img').forEach(($img) => {
+      resetAttribute($img, 'src');
+    });
+    element.querySelectorAll('picture source').forEach(($source) => {
+      resetAttribute($source, 'srcset');
+    });
+  }
+}
+
 function postLCP() {
   loadFonts();
   const martechUrl = '/express/scripts/martech.js';
@@ -641,7 +713,7 @@ async function fetchAuthorImage($image, author) {
     $div.innerHTML = main;
     const $img = $div.querySelector('img');
     const src = $img.src.replace('width=2000', 'width=200');
-    $image.src = src;
+    $image.src = getOptimizedImageURL(src);
   }
 }
 
@@ -929,78 +1001,6 @@ function splitSections() {
       unwrapBlock($block);
     }
   });
-}
-
-function supportsWebp() {
-  return window.webpSupport;
-}
-
-// Google official webp detection
-function checkWebpFeature(callback) {
-  const webpSupport = sessionStorage.getItem('webpSupport');
-  if (!webpSupport) {
-    const kTestImages = 'UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoBAAEADsD+JaQAA3AAAAAA';
-    const img = new Image();
-    img.onload = () => {
-      const result = (img.width > 0) && (img.height > 0);
-      window.webpSupport = result;
-      sessionStorage.setItem('webpSupport', result);
-      callback();
-    };
-    img.onerror = () => {
-      sessionStorage.setItem('webpSupport', false);
-      window.webpSupport = false;
-      callback();
-    };
-    img.src = `data:image/webp;base64,${kTestImages}`;
-  } else {
-    window.webpSupport = (webpSupport === 'true');
-    callback();
-  }
-}
-
-export function getOptimizedImageURL(src) {
-  const url = new URL(src, window.location.href);
-  let result = src;
-  const { pathname, search } = url;
-  if (pathname.includes('media_')) {
-    const usp = new URLSearchParams(search);
-    usp.delete('auto');
-    if (!supportsWebp()) {
-      if (pathname.endsWith('.png')) {
-        usp.set('format', 'png');
-      } else if (pathname.endsWith('.gif')) {
-        usp.set('format', 'gif');
-      } else {
-        usp.set('format', 'pjpg');
-      }
-    } else {
-      usp.set('format', 'webply');
-    }
-    result = `${src.split('?')[0]}?${usp.toString()}`;
-  }
-  return (result);
-}
-
-function resetAttribute($elem, attrib) {
-  const src = $elem.getAttribute(attrib);
-  if (src) {
-    const oSrc = getOptimizedImageURL(src);
-    if (oSrc !== src) {
-      $elem.setAttribute(attrib, oSrc);
-    }
-  }
-}
-
-export function webpPolyfill(element) {
-  if (!supportsWebp()) {
-    element.querySelectorAll('img').forEach(($img) => {
-      resetAttribute($img, 'src');
-    });
-    element.querySelectorAll('picture source').forEach(($source) => {
-      resetAttribute($source, 'srcset');
-    });
-  }
 }
 
 function setTheme() {


### PR DESCRIPTION
Fix https://github.com/adobe/express-website-issues/issues/71

I had to re-shuffle a lot of code because of linting (`getOptimizedImageURL` method and co were defined at the end of the file).
Only one line change: https://github.com/adobe/spark-website/pull/129/files#diff-f2fe3cbdc03569b7c92dcf81b2a7b2c84a79958faac5f1bedf61303f77c38c87L644