### PR TITLE
chore(ci): limit purge code to hlx.page

### DIFF
--- a/.github/workflows/purge-code.yaml
+++ b/.github/workflows/purge-code.yaml
@@ -12,5 +12,5 @@ jobs:
         id: trigger
         uses: adobe-rnd/github-purge-cache-action@master
         with:
-          helix-url: https://spark-website--adobe.hlx.live/
+          helix-url: https://spark-website--adobe.hlx.page/
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`spark-website--adobe.hlx.live` now responds `400` to `HLXPURGE`. It gets updated via code bus.