### PR TITLE
fix: remove extra spacing above footer

### DIFF
--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -563,7 +563,7 @@ main .section-wrapper:first-of-type {
 }
 
 main .section-wrapper:last-of-type {
-  padding-bottom: 80px;
+  padding-bottom: 120px;
 }
 
 main .section-wrapper > div {
@@ -747,6 +747,10 @@ main .section-wrapper .hero {
 
   main .section-wrapper:first-of-type {
     padding-top: 0;
+  }
+
+  main .section-wrapper:last-of-type {
+    padding-bottom: 80px;
   }
 
     main .section-wrapper h2 {

--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -282,11 +282,6 @@ body.no-brand-header header, body.no-desktop-brand-header header {
     }
 }
 
-footer {
-
-  margin-top: 120px;
-}
-
 /* buttons */
 
 a.button:any-link {
@@ -565,6 +560,10 @@ main .section-wrapper:first-of-type {
 
 main .section-wrapper:first-of-type {
   padding: 0;
+}
+
+main .section-wrapper:last-of-type {
+  padding-bottom: 80px;
 }
 
 main .section-wrapper > div {


### PR DESCRIPTION
Fix https://github.com/adobe/express-website-issues/issues/189

Removing fixed top margin in footer while making sure the last section has a reasonable bottom padding so its contents won't stick to the footer.

- Before: https://w36--spark-website--adobe.hlx3.page/express/create/spotlight/banner-t2
- After: https://issue-189--spark-website--adobe.hlx3.page/express/create/spotlight/banner-t2