### PR TITLE
feat: catch window resize and re-compute image size

### DIFF
--- a/express/blocks/how-to-steps-carousel/how-to-steps-carousel.js
+++ b/express/blocks/how-to-steps-carousel/how-to-steps-carousel.js
@@ -19,6 +19,21 @@ import {
 let rotationInterval;
 let fixedImageSize = false;
 
+function reset(block) {
+  const window = block.ownerDocument.defaultView;
+
+  window.clearInterval(rotationInterval);
+  rotationInterval = null;
+
+  const container = block.parentElement.parentElement;
+  const picture = container.querySelector('picture');
+
+  delete picture.style.height;
+  container.classList.remove('no-cover');
+
+  fixedImageSize = false;
+}
+
 function activate(block, target) {
   if (!fixedImageSize) {
     // trick to fix the image height when vw > 900 and avoid image resize when toggling the tips
@@ -144,6 +159,12 @@ export default function decorate(block) {
       row.classList.add('active');
       number.classList.add('active');
     }
+  });
+
+  window.addEventListener('resize', () => {
+    reset(block);
+    activate(block, block.querySelector('.tip-number.tip-1'));
+    initRotation(window, document);
   });
 
   initRotation(window, document);


### PR DESCRIPTION
Improve carousel: handle window resize, i.e. re-compute the image height (including cover or not).