### PR TITLE
fix: template list on create page

### DIFF
--- a/express/blocks/template-list/template-list.js
+++ b/express/blocks/template-list/template-list.js
@@ -188,7 +188,6 @@ async function decorateTemplateList($block) {
             src: $imgLink.href,
             type: 'video/mp4',
           }));
-          console.log($parent);
           $parent.replaceChild($video, $picture);
           $imgLink.remove();
           $video.addEventListener('canplay', () => {


### PR DESCRIPTION
https://create-page-fix--spark-website--adobe.hlx3.page/express/create
vs.
https://main--spark-website--adobe.hlx3.page/express/create